### PR TITLE
Temporarily remove @piecuu from webring

### DIFF
--- a/webring.nix
+++ b/webring.nix
@@ -12,7 +12,6 @@
     { name = "korolr"; site = "https://korolr.dev"; config = "https://github.com/korolr/nixos-config"; }
     { name = "emo-mruczek"; site = "https://emo-mruczek.pl"; config = "https://github.com/emo-mruczek/niksos-confg"; }
     { name = "mat"; site = "https://allpurposem.at"; config = "https://git.allpurposem.at/mat/Computer"; }
-    { name = "piecuu"; site = "https://piecuu.pl"; config = "https://git.piecuu.pl/Piecuu/nixos-flake"; }
     { name = "cutedog5695"; site = "https://cutedog5695.me"; config = "https://github.com/CuteDog5695/nixos-config"; }
     { name = "bwkam"; site = "https://bwkam.github.io"; config = "https://github.com/bwkam/dots"; }
     { name = "MarkAssPandi"; site = "https://markasspandi.pl"; config = "https://codeberg.org/MicroPanda123/nixosos"; }


### PR DESCRIPTION
Server room flooded, had to evacuate servers. The PR could also not be pulled in, but then it would hurt the guests clicking next/random on sites and mine not loading. I'm aiming to get back online in a couple of days.