### PR TITLE
add bricked

### DIFF
--- a/webring.nix
+++ b/webring.nix
@@ -20,4 +20,5 @@
     { name = "sioodmy"; site = "https://sioodmy.dev"; config = "https://github.com/sioodmy/dotfiles"; }
     { name = "maydayv7"; site = "https://maydayv7.site"; config = "https://github.com/maydayv7/dotfiles"; }
     { name = "mimvoid"; site = "https://mimvoid.neocities.org"; config = "https://github.com/mimvoid/nix-config"; }
+    { name = "bricked"; site = "https://bricked.dev"; config = "https://nixdots.bricked.dev"; }
 ]


### PR DESCRIPTION
Adds https://bricked.dev/ to the webring. Mirror of https://codeberg.org/jacekpoz/nixwebr.ing/pulls/6 because I figured you may be quicker to respond on GitHub.